### PR TITLE
Add nftables package to alpine-dbg testing image

### DIFF
--- a/alpine-docker-dbg/Dockerfile
+++ b/alpine-docker-dbg/Dockerfile
@@ -8,7 +8,8 @@ RUN apk update && apk add \
     strace \
     tree \
     libcap \
-    bind-tools
+    bind-tools \
+    nftables
 
 RUN sed -i 's/v3.10/latest-stable/g' /etc/apk/repositories && apk update && apk add docker
 


### PR DESCRIPTION
'nft' package is required during the execution of a few integration testcases that inspect the firewall rules inserted by sysbox-runc. These testcases have been extended to work on distros where the system is relying on 'nftables' backend (e.g. CentOS, Fedora, etc) instead of the traditional iptables.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>