### PR TITLE
Enhance kindind dockerfiles with latest suggestions

### DIFF
--- a/kindind/1.18/Dockerfile
+++ b/kindind/1.18/Dockerfile
@@ -10,9 +10,36 @@
 # K8s.io KinD inside a Sysbox container, the Sysbox container acts as secure
 # boundary around that entire K8s cluster.
 #
-# Usage:
+# Build Process
+# =============
 #
-# $ docker run --runtime=sysbox-runc -it --rm -P --name=syscont nestybox/kindind
+# BUILDING THIS IMAGE REQUIRES CONFIGURING SYSBOX-RUNC AS DOCKER'S DEFAULT
+# RUNTIME DURING THE BUILD. REFER TO [THIS](https://github.com/nestybox/sysbox/blob/master/docs/quickstart/images.md#building-a-system-container-that-includes-inner-container-images)
+# DOC FOR MORE DETAILS.
+#
+# $ sudo more /etc/docker/daemon.json
+#{
+#    "default-runtime": "sysbox-runc",
+#    "runtimes": {
+#        "sysbox-runc": {
+#            "path": "/usr/bin/sysbox-runc"
+#        }
+#    }
+#}
+#
+# $ sudo systemctl restart docker
+# $ docker build -t nestybox/k8s-node:<k8s_version> .
+#
+# E.g.,
+#
+# $ docker build -t nestybox/kindind:v1.18.2 .
+#
+# Once the build completes, you can revert the default runtime config if you wish.
+#
+# Usage
+# =====
+#
+# $ docker run --runtime=sysbox-runc -it --rm -P --name=syscont nestybox/kindind:v1.18.2
 #
 # This will spawn a sys container which contains systemd, Docker, and the K8s.io
 # KinD tool inside. Systemd login is "admin/admin". Once you log in you can run
@@ -46,8 +73,10 @@ RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key
     && rm -rf /var/lib/apt/lists/*
 
 # K8s.io KinD
-RUN git clone https://github.com/kubernetes-sigs/kind.git /home/admin/kind
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64 \
+    && chmod +x ./kind \
+    && mv ./kind /usr/bin/kind
 
-# Build the KinD tool
-COPY build-kind.sh /usr/bin
-RUN chmod +x /usr/bin/build-kind.sh && build-kind.sh && rm /usr/bin/build-kind.sh
+# Pre-fetch kindnestnode image to be utilized by KinD tool
+COPY download-node-img.sh /usr/bin
+RUN chmod +x /usr/bin/download-node-img.sh && download-node-img.sh && rm /usr/bin/download-node-img.sh

--- a/kindind/1.18/download-node-img.sh
+++ b/kindind/1.18/download-node-img.sh
@@ -4,16 +4,7 @@
 dockerd > /var/log/dockerd.log 2>&1 &
 sleep 3
 
-# build K8s.io KinD
-cd /home/admin/kind
-git pull
-make
-cp bin/kind /usr/local/bin
-
-# Remove the golang image used during the kind build (not needed anymore)
-docker image rm $(docker image ls -aq)
-
 # Preload the nestybox/kindestnode:v1.18.2 image (temporarily needed for
 # the kind cluster nodes to bypass a bug in the OCI runc used inside
 # these nodes).
-docker pull nestybox/kindestnode:v1.18.2
+docker pull registry.nestybox.com/nestybox/kindestnode:v1.18.2

--- a/kindind/1.19/Dockerfile
+++ b/kindind/1.19/Dockerfile
@@ -1,0 +1,82 @@
+#
+# kindind: kubernetes-in-docker ... in docker :)
+#
+#
+# Why?
+#
+# This is useful as a way of encapsulating a full K8s cluster in a single
+# container image and properly isolating it from the underlying host. On the
+# latter point, K8s.io KinD uses unsecure privileged containers; by placing
+# K8s.io KinD inside a Sysbox container, the Sysbox container acts as secure
+# boundary around that entire K8s cluster.
+#
+# Build Process
+# =============
+#
+# BUILDING THIS IMAGE REQUIRES CONFIGURING SYSBOX-RUNC AS DOCKER'S DEFAULT
+# RUNTIME DURING THE BUILD. REFER TO [THIS](https://github.com/nestybox/sysbox/blob/master/docs/quickstart/images.md#building-a-system-container-that-includes-inner-container-images)
+# DOC FOR MORE DETAILS.
+#
+# $ sudo more /etc/docker/daemon.json
+#{
+#    "default-runtime": "sysbox-runc",
+#    "runtimes": {
+#        "sysbox-runc": {
+#            "path": "/usr/bin/sysbox-runc"
+#        }
+#    }
+#}
+#
+# $ sudo systemctl restart docker
+# $ docker build -t nestybox/k8s-node:<k8s_version> .
+#
+# E.g.,
+#
+# $ docker build -t nestybox/kindind:v1.19.4 .
+#
+# Once the build completes, you can revert the default runtime config if you wish.
+#
+# Usage
+# =====
+#
+# $ docker run --runtime=sysbox-runc -it --rm -P --name=syscont nestybox/kindind:v1.19.4
+#
+# This will spawn a sys container which contains systemd, Docker, and the K8s.io
+# KinD tool inside. Systemd login is "admin/admin". Once you log in you can run
+# K8s.io KinD as if you were in a VM. E.g.,:
+#
+# $ kind create cluster --image=nestybox/kindestnode:v1.19.4
+#
+# The "nestybox/kindestnode:v1.19.4" image is currently required due to a bug in
+# the OCI runc that prevents it from running correctly inside a system
+# container. Note that in this case said runc is running inside a privileged
+# container (deployed by k8s.io kind) that is inside a system container (where
+# that privileged container is only privileged with respect to the system
+# container, not with respect to the host).
+#
+
+FROM nestybox/ubuntu-bionic-systemd-docker:latest
+
+RUN apt-get update && apt-get install -y \
+    git \
+    make
+
+# kubectl (with bash completion)
+ARG k8s_version=v1.19.4
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -  \
+    && echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list \
+    && apt-get update \
+    && apt-get install kubectl="${k8s_version#v}"-00 \
+    && apt-get install bash-completion \
+    && kubectl completion bash >/etc/bash_completion.d/kubectl \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# K8s.io KinD
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64 \
+    && chmod +x ./kind \
+    && mv ./kind /usr/bin/kind
+
+# Pre-fetch kindnestnode image to be utilized by KinD tool
+COPY download-node-img.sh /usr/bin
+RUN chmod +x /usr/bin/download-node-img.sh && download-node-img.sh && rm /usr/bin/download-node-img.sh

--- a/kindind/1.19/download-node-img.sh
+++ b/kindind/1.19/download-node-img.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# start dockerd (needed for building KinD)
+dockerd > /var/log/dockerd.log 2>&1 &
+sleep 3
+
+# Preload the nestybox/kindestnode:v1.19.4 image (temporarily needed for
+# the kind cluster nodes to bypass a bug in the OCI runc used inside
+# these nodes).
+docker pull registry.nestybox.com/nestybox/kindestnode:v1.19.4

--- a/kindind/1.20/Dockerfile
+++ b/kindind/1.20/Dockerfile
@@ -1,0 +1,82 @@
+#
+# kindind: kubernetes-in-docker ... in docker :)
+#
+#
+# Why?
+#
+# This is useful as a way of encapsulating a full K8s cluster in a single
+# container image and properly isolating it from the underlying host. On the
+# latter point, K8s.io KinD uses unsecure privileged containers; by placing
+# K8s.io KinD inside a Sysbox container, the Sysbox container acts as secure
+# boundary around that entire K8s cluster.
+#
+# Build Process
+# =============
+#
+# BUILDING THIS IMAGE REQUIRES CONFIGURING SYSBOX-RUNC AS DOCKER'S DEFAULT
+# RUNTIME DURING THE BUILD. REFER TO [THIS](https://github.com/nestybox/sysbox/blob/master/docs/quickstart/images.md#building-a-system-container-that-includes-inner-container-images)
+# DOC FOR MORE DETAILS.
+#
+# $ sudo more /etc/docker/daemon.json
+#{
+#    "default-runtime": "sysbox-runc",
+#    "runtimes": {
+#        "sysbox-runc": {
+#            "path": "/usr/bin/sysbox-runc"
+#        }
+#    }
+#}
+#
+# $ sudo systemctl restart docker
+# $ docker build -t nestybox/k8s-node:<k8s_version> .
+#
+# E.g.,
+#
+# $ docker build -t nestybox/kindind:v1.20.2 .
+#
+# Once the build completes, you can revert the default runtime config if you wish.
+#
+# Usage
+# =====
+#
+# $ docker run --runtime=sysbox-runc -it --rm -P --name=syscont nestybox/kindind:v1.20.2
+#
+# This will spawn a sys container which contains systemd, Docker, and the K8s.io
+# KinD tool inside. Systemd login is "admin/admin". Once you log in you can run
+# K8s.io KinD as if you were in a VM. E.g.,:
+#
+# $ kind create cluster --image=nestybox/kindestnode:v1.20.2
+#
+# The "nestybox/kindestnode:v1.20.2" image is currently required due to a bug in
+# the OCI runc that prevents it from running correctly inside a system
+# container. Note that in this case said runc is running inside a privileged
+# container (deployed by k8s.io kind) that is inside a system container (where
+# that privileged container is only privileged with respect to the system
+# container, not with respect to the host).
+#
+
+FROM nestybox/ubuntu-bionic-systemd-docker:latest
+
+RUN apt-get update && apt-get install -y \
+    git \
+    make
+
+# kubectl (with bash completion)
+ARG k8s_version=v1.20.2
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -  \
+    && echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list \
+    && apt-get update \
+    && apt-get install kubectl="${k8s_version#v}"-00 \
+    && apt-get install bash-completion \
+    && kubectl completion bash >/etc/bash_completion.d/kubectl \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# K8s.io KinD
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64 \
+    && chmod +x ./kind \
+    && mv ./kind /usr/bin/kind
+
+# Pre-fetch kindnestnode image to be utilized by KinD tool
+COPY download-node-img.sh /usr/bin
+RUN chmod +x /usr/bin/download-node-img.sh && download-node-img.sh && rm /usr/bin/download-node-img.sh

--- a/kindind/1.20/download-node-img.sh
+++ b/kindind/1.20/download-node-img.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# start dockerd (needed for building KinD)
+dockerd > /var/log/dockerd.log 2>&1 &
+sleep 3
+
+# Preload the nestybox/kindestnode:v1.20.2 image (temporarily needed for
+# the kind cluster nodes to bypass a bug in the OCI runc used inside
+# these nodes).
+docker pull registry.nestybox.com/nestybox/kindestnode:v1.20.2


### PR DESCRIPTION
Made the following changes:

* Added instructions to build images.
* Updated Kind instalation procedure to rely on latest stable release and not on the latest code.
* Modified image pre-fetching script to account for Kind's new installation approach.
* Adjusted kindestnode pointer to refer to registry.nestybox.com.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>