### PR TITLE
Add Dockerfiles for Enterprise Linux (AlmaLinux, RockyLinux and CentOS Stream)

### DIFF
--- a/almalinux-8-systemd-docker/Dockerfile
+++ b/almalinux-8-systemd-docker/Dockerfile
@@ -1,0 +1,45 @@
+# Sample container image with AlmaLinux + Systemd + Sshd + Docker.
+#
+# Usage:
+#
+# $ docker run --runtime=sysbox-runc -it --rm -P --name=syscont nestybox/almalinux-8-systemd-docker
+#
+# This will run systemd and prompt for a user login; the default
+# user/password in this image is "admin/admin". Once you log in you
+# can run Docker inside as usual. You can also ssh into the image:
+#
+# $ ssh admin@<host-ip> -p <host-port>
+#
+# where <host-port> is chosen by Docker and mapped into the system container's sshd port.
+#
+
+FROM nestybox/almalinux-8-systemd:latest
+
+# Docker install
+RUN dnf install -y dnf-plugins-core &&                                                       \
+    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install -y docker-ce docker-ce-cli containerd.io &&                                  \
+    systemctl enable docker &&                                                               \
+                                                                                             \
+    # Housekeeping
+    dnf clean all &&                                                                         \
+    rm -rf                                                                                   \
+       /var/cache/dnf/*                                                                      \
+       /var/log/*                                                                            \
+       /tmp/*                                                                                \
+       /var/tmp/*                                                                            \
+       /usr/share/doc/*                                                                      \
+       /usr/share/man/* &&                                                                   \
+                                                                                             \
+    # Add user "admin" to the Docker group
+    usermod -a -G docker admin
+
+# Sshd install
+RUN dnf install -y openssh-server &&                                                         \
+    mkdir /home/admin/.ssh &&                                                                \
+    chown admin:admin /home/admin/.ssh
+
+EXPOSE 22
+
+# Set systemd as entrypoint.
+ENTRYPOINT [ "/sbin/init", "--log-level=err" ]

--- a/almalinux-8-systemd/Dockerfile
+++ b/almalinux-8-systemd/Dockerfile
@@ -1,0 +1,57 @@
+# Sample container image with AlmaLinux + Systemd
+#
+# Description:
+#
+# This image serves as a basic reference example for user's looking to
+# run Systemd inside a system container in order to deploy various
+# services within the system container, or use it as a virtual host
+# environment.
+#
+# Usage:
+#
+# $ docker run --runtime=sysbox-runc -it --rm --name=syscont nestybox/almalinux-8-systemd
+#
+# This will run systemd and prompt for a user login; the default user/password
+# in this image is "admin/admin".
+
+FROM almalinux:8
+
+#
+# Systemd installation
+#
+RUN dnf install -y \
+        iptables   \
+        iproute    \
+        kmod       \
+        procps-ng  \
+        sudo       \
+        udev &&    \
+    # Unmask services
+    systemctl unmask                                                  \
+        systemd-remount-fs.service                                    \
+        dev-hugepages.mount                                           \
+        sys-fs-fuse-connections.mount                                 \
+        systemd-logind.service                                        \
+        getty.target                                                  \
+        console-getty.service &&                                      \
+    # Prevents journald from reading kernel messages from /dev/kmsg
+    echo "ReadKMsg=no" >> /etc/systemd/journald.conf &&               \
+                                                                      \
+    # Housekeeping
+    dnf clean all &&                                                  \
+    rm -rf                                                            \
+       /var/cache/dnf/*                                               \
+       /var/log/*                                                     \
+       /tmp/*                                                         \
+       /var/tmp/*                                                     \
+       /usr/share/doc/*                                               \
+       /usr/share/man/* &&                                            \
+                                                                      \
+    # Create default 'admin/admin' user
+    useradd --create-home --shell /bin/bash admin -G wheel && echo "admin:admin" | chpasswd
+
+# Make use of stopsignal (instead of sigterm) to stop systemd containers.
+STOPSIGNAL SIGRTMIN+3
+
+# Set systemd as entrypoint.
+ENTRYPOINT [ "/sbin/init", "--log-level=err" ]

--- a/centos-stream-8-systemd-docker/Dockerfile
+++ b/centos-stream-8-systemd-docker/Dockerfile
@@ -1,0 +1,45 @@
+# Sample container image with CentOS Stream + Systemd + Sshd + Docker.
+#
+# Usage:
+#
+# $ docker run --runtime=sysbox-runc -it --rm -P --name=syscont nestybox/centos-stream-8-systemd-docker
+#
+# This will run systemd and prompt for a user login; the default
+# user/password in this image is "admin/admin". Once you log in you
+# can run Docker inside as usual. You can also ssh into the image:
+#
+# $ ssh admin@<host-ip> -p <host-port>
+#
+# where <host-port> is chosen by Docker and mapped into the system container's sshd port.
+#
+
+FROM nestybox/centos-stream-8-systemd:latest
+
+# Docker install
+RUN dnf install -y dnf-plugins-core &&                                                       \
+    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install -y docker-ce docker-ce-cli containerd.io &&                                  \
+    systemctl enable docker &&                                                               \
+                                                                                             \
+    # Housekeeping
+    dnf clean all &&                                                                         \
+    rm -rf                                                                                   \
+       /var/cache/dnf/*                                                                      \
+       /var/log/*                                                                            \
+       /tmp/*                                                                                \
+       /var/tmp/*                                                                            \
+       /usr/share/doc/*                                                                      \
+       /usr/share/man/* &&                                                                   \
+                                                                                             \
+    # Add user "admin" to the Docker group
+    usermod -a -G docker admin
+
+# Sshd install
+RUN dnf install -y openssh-server &&                                                         \
+    mkdir /home/admin/.ssh &&                                                                \
+    chown admin:admin /home/admin/.ssh
+
+EXPOSE 22
+
+# Set systemd as entrypoint.
+ENTRYPOINT [ "/sbin/init", "--log-level=err" ]

--- a/centos-stream-8-systemd/Dockerfile
+++ b/centos-stream-8-systemd/Dockerfile
@@ -1,0 +1,57 @@
+# Sample container image with CentOS Stream + Systemd
+#
+# Description:
+#
+# This image serves as a basic reference example for user's looking to
+# run Systemd inside a system container in order to deploy various
+# services within the system container, or use it as a virtual host
+# environment.
+#
+# Usage:
+#
+# $ docker run --runtime=sysbox-runc -it --rm --name=syscont nestybox/centos-stream-8-systemd
+#
+# This will run systemd and prompt for a user login; the default user/password
+# in this image is "admin/admin".
+
+FROM quay.io/centos/centos:stream8
+
+#
+# Systemd installation
+#
+RUN dnf install -y \
+        iptables   \
+        iproute    \
+        kmod       \
+        procps-ng  \
+        sudo       \
+        udev &&    \
+    # Unmask services
+    systemctl unmask                                                  \
+        systemd-remount-fs.service                                    \
+        dev-hugepages.mount                                           \
+        sys-fs-fuse-connections.mount                                 \
+        systemd-logind.service                                        \
+        getty.target                                                  \
+        console-getty.service &&                                      \
+    # Prevents journald from reading kernel messages from /dev/kmsg
+    echo "ReadKMsg=no" >> /etc/systemd/journald.conf &&               \
+                                                                      \
+    # Housekeeping
+    dnf clean all &&                                                  \
+    rm -rf                                                            \
+       /var/cache/dnf/*                                               \
+       /var/log/*                                                     \
+       /tmp/*                                                         \
+       /var/tmp/*                                                     \
+       /usr/share/doc/*                                               \
+       /usr/share/man/* &&                                            \
+                                                                      \
+    # Create default 'admin/admin' user
+    useradd --create-home --shell /bin/bash admin -G wheel && echo "admin:admin" | chpasswd
+
+# Make use of stopsignal (instead of sigterm) to stop systemd containers.
+STOPSIGNAL SIGRTMIN+3
+
+# Set systemd as entrypoint.
+ENTRYPOINT [ "/sbin/init", "--log-level=err" ]

--- a/rockylinux-8-systemd-docker/Dockerfile
+++ b/rockylinux-8-systemd-docker/Dockerfile
@@ -1,0 +1,45 @@
+# Sample container image with Rocky Linux + Systemd + Sshd + Docker.
+#
+# Usage:
+#
+# $ docker run --runtime=sysbox-runc -it --rm -P --name=syscont nestybox/rockylinux-8-systemd-docker
+#
+# This will run systemd and prompt for a user login; the default
+# user/password in this image is "admin/admin". Once you log in you
+# can run Docker inside as usual. You can also ssh into the image:
+#
+# $ ssh admin@<host-ip> -p <host-port>
+#
+# where <host-port> is chosen by Docker and mapped into the system container's sshd port.
+#
+
+FROM nestybox/rockylinux-8-systemd:latest
+
+# Docker install
+RUN dnf install -y dnf-plugins-core &&                                                       \
+    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install -y docker-ce docker-ce-cli containerd.io &&                                  \
+    systemctl enable docker &&                                                               \
+                                                                                             \
+    # Housekeeping
+    dnf clean all &&                                                                         \
+    rm -rf                                                                                   \
+       /var/cache/dnf/*                                                                      \
+       /var/log/*                                                                            \
+       /tmp/*                                                                                \
+       /var/tmp/*                                                                            \
+       /usr/share/doc/*                                                                      \
+       /usr/share/man/* &&                                                                   \
+                                                                                             \
+    # Add user "admin" to the Docker group
+    usermod -a -G docker admin
+
+# Sshd install
+RUN dnf install -y openssh-server &&                                                         \
+    mkdir /home/admin/.ssh &&                                                                \
+    chown admin:admin /home/admin/.ssh
+
+EXPOSE 22
+
+# Set systemd as entrypoint.
+ENTRYPOINT [ "/sbin/init", "--log-level=err" ]

--- a/rockylinux-8-systemd/Dockerfile
+++ b/rockylinux-8-systemd/Dockerfile
@@ -1,0 +1,57 @@
+# Sample container image with Rocky Linux + Systemd
+#
+# Description:
+#
+# This image serves as a basic reference example for user's looking to
+# run Systemd inside a system container in order to deploy various
+# services within the system container, or use it as a virtual host
+# environment.
+#
+# Usage:
+#
+# $ docker run --runtime=sysbox-runc -it --rm --name=syscont nestybox/rockylinux-8-systemd
+#
+# This will run systemd and prompt for a user login; the default user/password
+# in this image is "admin/admin".
+
+FROM rockylinux:8
+
+#
+# Systemd installation
+#
+RUN dnf install -y \
+        iptables   \
+        iproute    \
+        kmod       \
+        procps-ng  \
+        sudo       \
+        udev &&    \
+    # Unmask services
+    systemctl unmask                                                  \
+        systemd-remount-fs.service                                    \
+        dev-hugepages.mount                                           \
+        sys-fs-fuse-connections.mount                                 \
+        systemd-logind.service                                        \
+        getty.target                                                  \
+        console-getty.service &&                                      \
+    # Prevents journald from reading kernel messages from /dev/kmsg
+    echo "ReadKMsg=no" >> /etc/systemd/journald.conf &&               \
+                                                                      \
+    # Housekeeping
+    dnf clean all &&                                                  \
+    rm -rf                                                            \
+       /var/cache/dnf/*                                               \
+       /var/log/*                                                     \
+       /tmp/*                                                         \
+       /var/tmp/*                                                     \
+       /usr/share/doc/*                                               \
+       /usr/share/man/* &&                                            \
+                                                                      \
+    # Create default 'admin/admin' user
+    useradd --create-home --shell /bin/bash admin -G wheel && echo "admin:admin" | chpasswd
+
+# Make use of stopsignal (instead of sigterm) to stop systemd containers.
+STOPSIGNAL SIGRTMIN+3
+
+# Set systemd as entrypoint.
+ENTRYPOINT [ "/sbin/init", "--log-level=err" ]


### PR DESCRIPTION
DockerFiles for AlmaLinux and RockyLinux:
- Container image with AlmaLinux + Systemd
- Container image with AlmaLinux + Systemd + Sshd + Docker
- Container image with Rocky Linux + Systemd
- Container image with  Rocky Linux + Systemd + Sshd + Docker
- Container image with CentOS Stream + Systemd
- Container image with  CentOS Stream + Systemd + Sshd + Docker