### PR TITLE
Add Dockerfiles for Ubuntu 22.04 LTS (Jammy Jellyfish) Beta

### DIFF
--- a/ubuntu-jammy-compose/Dockerfile
+++ b/ubuntu-jammy-compose/Dockerfile
@@ -1,0 +1,11 @@
+#
+# Ubuntu Jammy + Docker + Compose
+#
+# Instructions for Docker compose installation taken from:
+# https://docs.docker.com/compose/install/
+#
+
+FROM nestybox/ubuntu-jammy-docker:latest
+
+RUN curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose

--- a/ubuntu-jammy-docker-dbg/Dockerfile
+++ b/ubuntu-jammy-docker-dbg/Dockerfile
@@ -1,0 +1,21 @@
+#
+# Ubuntu Jammy + Docker
+#
+# Instructions for docker installation taken from:
+# https://docs.docker.com/install/linux/docker-ce/ubuntu/
+#
+
+FROM nestybox/ubuntu-jammy-docker:latest
+
+# Debug utilities
+RUN apt-get update && apt-get install -y \
+       procps \
+       psmisc \
+       nano \
+       strace \
+       net-tools \
+       less \
+       wget \
+       iproute2
+
+CMD ["/bin/bash"]

--- a/ubuntu-jammy-docker-dbg/Dockerfile
+++ b/ubuntu-jammy-docker-dbg/Dockerfile
@@ -1,8 +1,5 @@
 #
-# Ubuntu Jammy + Docker
-#
-# Instructions for docker installation taken from:
-# https://docs.docker.com/install/linux/docker-ce/ubuntu/
+# Ubuntu Jammy + Docker + Debug tools
 #
 
 FROM nestybox/ubuntu-jammy-docker:latest

--- a/ubuntu-jammy-docker/Dockerfile
+++ b/ubuntu-jammy-docker/Dockerfile
@@ -1,0 +1,24 @@
+#
+# Ubuntu Jammy + Docker
+#
+# Instructions for docker installation taken from:
+# https://docs.docker.com/install/linux/docker-ce/ubuntu/
+#
+
+FROM ubuntu:jammy
+
+# Docker install
+RUN apt-get update && apt-get install --no-install-recommends -y \
+       apt-transport-https \
+       ca-certificates \
+       curl \
+       gnupg-agent \
+       software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN apt-key fingerprint 0EBFCD88
+
+RUN add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+       $(lsb_release -cs) \
+       stable"
+RUN apt-get update && apt-get install --no-install-recommends -y docker-ce docker-ce-cli containerd.io

--- a/ubuntu-jammy-systemd-docker-custom/Dockerfile
+++ b/ubuntu-jammy-systemd-docker-custom/Dockerfile
@@ -1,0 +1,25 @@
+# Sample container image with Ubuntu Jammy + Systemd + Sshd + Docker + Custom entry-point.
+#
+# Usage:
+#
+# $ docker run --runtime=sysbox-runc -it --rm -P --name=syscont nestybox/ubuntu-jammy-systemd-jammy-custom
+#
+# This will run systemd and prompt for a user login; the default
+# user/password in this image is "admin/admin". Once you log in you
+# can run Docker inside as usual. You can also ssh into the image:
+#
+# $ ssh admin@<host-ip> -p <host-port>
+#
+# where <host-port> is chosen by Docker and mapped into the system container's sshd port.
+#
+
+FROM nestybox/ubuntu-jammy-systemd-docker:latest
+
+# Example of a systemd service created to showcase a custom entry-point.
+COPY script.sh /usr/bin/
+COPY custom.service /lib/systemd/system/
+RUN chmod +x /usr/bin/script.sh &&                               \
+    ln -sf /lib/systemd/system/custom.service                    \
+       /etc/systemd/system/multi-user.target.wants/custom.service
+
+

--- a/ubuntu-jammy-systemd-docker-custom/custom.service
+++ b/ubuntu-jammy-systemd-docker-custom/custom.service
@@ -1,0 +1,12 @@
+Unit]
+Description=Random script execution
+After=docker.service
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/script.sh
+ExecReload=/usr/bin/script.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/ubuntu-jammy-systemd-docker-custom/script.sh
+++ b/ubuntu-jammy-systemd-docker-custom/script.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+sleep 3600

--- a/ubuntu-jammy-systemd-docker/Dockerfile
+++ b/ubuntu-jammy-systemd-docker/Dockerfile
@@ -1,0 +1,64 @@
+# Sample container image with Ubuntu Jammy + Systemd + Sshd + Docker.
+#
+# Usage:
+#
+# $ docker run --runtime=sysbox-runc -it --rm -P --name=syscont nestybox/ubuntu-jammy-systemd-docker
+#
+# This will run systemd and prompt for a user login; the default
+# user/password in this image is "admin/admin". Once you log in you
+# can run Docker inside as usual. You can also ssh into the image:
+#
+# $ ssh admin@<host-ip> -p <host-port>
+#
+# where <host-port> is chosen by Docker and mapped into the system container's sshd port.
+#
+
+FROM nestybox/ubuntu-jammy-systemd:latest
+
+# Docker install
+RUN apt-get update && apt-get install --no-install-recommends -y      \
+       apt-transport-https                                            \
+       ca-certificates                                                \
+       curl                                                           \
+       gnupg-agent                                                    \
+       software-properties-common &&                                  \
+                                                                      \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg           \
+         | apt-key add - &&                                           \
+	                                                              \
+    apt-key fingerprint 0EBFCD88 &&                                   \
+                                                                      \
+    add-apt-repository                                                \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu     \
+       $(lsb_release -cs)                                             \
+       stable" &&                                                     \
+                                                                      \
+    apt-get update && apt-get install --no-install-recommends -y      \
+       docker-ce docker-ce-cli containerd.io &&                       \
+                                                                      \
+    # Housekeeping
+    apt-get clean -y &&                                               \
+    rm -rf                                                            \
+       /var/cache/debconf/*                                           \
+       /var/lib/apt/lists/*                                           \
+       /var/log/*                                                     \
+       /tmp/*                                                         \
+       /var/tmp/*                                                     \
+       /usr/share/doc/*                                               \
+       /usr/share/man/*                                               \
+       /usr/share/local/* &&                                          \
+                                                                      \
+    # Add user "admin" to the Docker group
+    usermod -a -G docker admin
+
+# Sshd install
+RUN apt-get update && apt-get install --no-install-recommends -y      \
+            openssh-server &&                                         \
+    mkdir /home/admin/.ssh &&                                         \
+    chown admin:admin /home/admin/.ssh
+
+EXPOSE 22
+
+# Set systemd as entrypoint.
+ENTRYPOINT [ "/sbin/init", "--log-level=err" ]
+

--- a/ubuntu-jammy-systemd/Dockerfile
+++ b/ubuntu-jammy-systemd/Dockerfile
@@ -1,0 +1,59 @@
+# Sample container image with Ubuntu Jammy + Systemd
+#
+# Description:
+#
+# This image serves as a basic reference example for user's looking to
+# run Systemd inside a system container in order to deploy various
+# services within the system container, or use it as a virtual host
+# environment.
+#
+# Usage:
+#
+# $ docker run --runtime=sysbox-runc -it --rm --name=syscont nestybox/ubuntu-jammy-systemd
+#
+# This will run systemd and prompt for a user login; the default user/password
+# in this image is "admin/admin".
+
+FROM ubuntu:jammy
+
+#
+# Systemd installation
+#
+RUN apt-get update &&                            \
+    apt-get install -y --no-install-recommends   \
+            systemd                              \
+            systemd-sysv                         \
+            libsystemd0                          \
+            ca-certificates                      \
+            dbus                                 \
+            iptables                             \
+            iproute2                             \
+            kmod                                 \
+            locales                              \
+            sudo                                 \
+            udev &&                              \
+                                                 \
+    # Prevents journald from reading kernel messages from /dev/kmsg
+    echo "ReadKMsg=no" >> /etc/systemd/journald.conf &&               \
+                                                                      \
+    # Housekeeping
+    apt-get clean -y &&                                               \
+    rm -rf                                                            \
+       /var/cache/debconf/*                                           \
+       /var/lib/apt/lists/*                                           \
+       /var/log/*                                                     \
+       /tmp/*                                                         \
+       /var/tmp/*                                                     \
+       /usr/share/doc/*                                               \
+       /usr/share/man/*                                               \
+       /usr/share/local/* &&                                          \
+                                                                      \
+    # Create default 'admin/admin' user
+    useradd --create-home --shell /bin/bash admin && echo "admin:admin" | chpasswd && adduser admin sudo
+
+# Make use of stopsignal (instead of sigterm) to stop systemd containers.
+STOPSIGNAL SIGRTMIN+3
+
+# Set systemd as entrypoint.
+ENTRYPOINT [ "/sbin/init", "--log-level=err" ]
+


### PR DESCRIPTION
As Ubuntu 22.04 LTS (Jammy Jellyfish) Beta release is available, I suggest to add related Dockerfiles.
https://releases.ubuntu.com/22.04/

The final release is expected on the 21st April.
See [Jammy Jellyfish Release Schedule](https://discourse.ubuntu.com/t/jammy-jellyfish-release-schedule/23906)