### PR TITLE
Update images relying on systemd services to mask certain services

### DIFF
--- a/k8s-node/1.20/Dockerfile
+++ b/k8s-node/1.20/Dockerfile
@@ -38,29 +38,13 @@
 #
 # Then run 'kubeadm init' in them just as you would on a physical host or VM.
 
-FROM nestybox/ubuntu-focal-systemd:latest
+FROM ghcr.io/nestybox/ubuntu-focal-systemd-docker:latest
 
 ARG k8s_version=v1.20.2
 
-# Install Docker.
-RUN apt-get update && apt-get install --no-install-recommends -y                        \
-       apt-transport-https                                                              \
-       ca-certificates                                                                  \
-       curl                                                                             \
-       gnupg-agent                                                                      \
-       software-properties-common                                                       \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -          \
-    && apt-key fingerprint 0EBFCD88                                                     \
-    && add-apt-repository                                                               \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu                       \
-       $(lsb_release -cs)                                                               \
-       stable"                                                                          \
-    && apt-get update                                                                   \
-    && apt-get install --no-install-recommends -y docker-ce docker-ce-cli containerd.io \
-    && rm -rf /var/lib/apt/lists/*                                                      \
-    # Add user "admin" to the Docker group                                              \
-    && usermod -a -G docker admin
-
+# Requirements for subsequent steps.
+RUN apt-get update && apt-get install --no-install-recommends -y software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Kubeadm.
 #

--- a/k8s-node/1.21/Dockerfile
+++ b/k8s-node/1.21/Dockerfile
@@ -38,29 +38,13 @@
 #
 # Then run 'kubeadm init' in them just as you would on a physical host or VM.
 
-FROM nestybox/ubuntu-focal-systemd:latest
+FROM ghcr.io/nestybox/ubuntu-focal-systemd-docker:latest
 
 ARG k8s_version=v1.21.12
 
-# Install Docker.
-RUN apt-get update && apt-get install --no-install-recommends -y                        \
-       apt-transport-https                                                              \
-       ca-certificates                                                                  \
-       curl                                                                             \
-       gnupg-agent                                                                      \
-       software-properties-common                                                       \
-    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -          \
-    && apt-key fingerprint 0EBFCD88                                                     \
-    && add-apt-repository                                                               \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu                       \
-       $(lsb_release -cs)                                                               \
-       stable"                                                                          \
-    && apt-get update                                                                   \
-    && apt-get install --no-install-recommends -y docker-ce docker-ce-cli containerd.io \
-    && rm -rf /var/lib/apt/lists/*                                                      \
-    # Add user "admin" to the Docker group                                              \
-    && usermod -a -G docker admin
-
+# Requirements for subsequent steps.
+RUN apt-get update && apt-get install --no-install-recommends -y software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Kubeadm.
 #

--- a/ubuntu-bionic-systemd-docker/Dockerfile
+++ b/ubuntu-bionic-systemd-docker/Dockerfile
@@ -14,49 +14,21 @@
 # where <host-port> is chosen by Docker and mapped into the system container's sshd port.
 #
 
-FROM nestybox/ubuntu-bionic-systemd:latest
+FROM ghcr.io/nestybox/ubuntu-bionic-systemd:latest
 
-# Docker install
-RUN apt-get update && apt-get install --no-install-recommends -y      \
-       apt-transport-https                                            \
-       ca-certificates                                                \
-       curl                                                           \
-       gnupg-agent                                                    \
-       software-properties-common &&                                  \
-                                                                      \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg           \
-         | apt-key add - &&                                           \
-	                                                              \
-    apt-key fingerprint 0EBFCD88 &&                                   \
-                                                                      \
-    add-apt-repository                                                \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu     \
-       $(lsb_release -cs)                                             \
-       stable" &&                                                     \
-                                                                      \
-    apt-get update && apt-get install --no-install-recommends -y      \
-       docker-ce docker-ce-cli containerd.io &&                       \
-                                                                      \
-    # Housekeeping
-    apt-get clean -y &&                                               \
-    rm -rf                                                            \
-       /var/cache/debconf/*                                           \
-       /var/lib/apt/lists/*                                           \
-       /var/log/*                                                     \
-       /tmp/*                                                         \
-       /var/tmp/*                                                     \
-       /usr/share/doc/*                                               \
-       /usr/share/man/*                                               \
-       /usr/share/local/* &&                                          \
-                                                                      \
+# Install Docker
+RUN apt-get update && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh \
     # Add user "admin" to the Docker group
-    usermod -a -G docker admin
+    && usermod -a -G docker admin
+ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker /etc/bash_completion.d/docker.sh
 
-# Sshd install
-RUN apt-get update && apt-get install --no-install-recommends -y      \
-            openssh-server &&                                         \
-    mkdir /home/admin/.ssh &&                                         \
-    chown admin:admin /home/admin/.ssh
+# Install Sshd
+RUN apt-get update && apt-get install --no-install-recommends -y openssh-server \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /home/admin/.ssh \
+    && chown admin:admin /home/admin/.ssh
 
 EXPOSE 22
 

--- a/ubuntu-bionic-systemd/Dockerfile
+++ b/ubuntu-bionic-systemd/Dockerfile
@@ -52,6 +52,15 @@ RUN apt-get update &&                            \
     # Create default 'admin/admin' user
     useradd --create-home --shell /bin/bash admin && echo "admin:admin" | chpasswd && adduser admin sudo
 
+# Disable systemd services/units that are unnecessary within a container.
+RUN systemctl mask systemd-udevd.service \
+                   systemd-udevd-kernel.socket \
+                   systemd-udevd-control.socket \
+                   systemd-modules-load.service \
+                   sys-kernel-config.mount \
+                   sys-kernel-debug.mount \
+                   sys-kernel-tracing.mount
+
 # Make use of stopsignal (instead of sigterm) to stop systemd containers.
 STOPSIGNAL SIGRTMIN+3
 

--- a/ubuntu-focal-systemd-docker/Dockerfile
+++ b/ubuntu-focal-systemd-docker/Dockerfile
@@ -13,52 +13,23 @@
 # where <host-port> is chosen by Docker and mapped into the system container's sshd port.
 #
 
-FROM nestybox/ubuntu-focal-systemd:latest
+FROM ghcr.io/nestybox/ubuntu-focal-systemd:latest
 
-# Docker install
-RUN apt-get update && apt-get install --no-install-recommends -y      \
-       apt-transport-https                                            \
-       ca-certificates                                                \
-       curl                                                           \
-       gnupg-agent                                                    \
-       software-properties-common &&                                  \
-                                                                      \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg           \
-         | apt-key add - &&                                           \
-	                                                              \
-    apt-key fingerprint 0EBFCD88 &&                                   \
-                                                                      \
-    add-apt-repository                                                \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu     \
-       $(lsb_release -cs)                                             \
-       stable" &&                                                     \
-                                                                      \
-    apt-get update && apt-get install --no-install-recommends -y      \
-       docker-ce docker-ce-cli containerd.io &&                       \
-                                                                      \
-    # Housekeeping
-    apt-get clean -y &&                                               \
-    rm -rf                                                            \
-       /var/cache/debconf/*                                           \
-       /var/lib/apt/lists/*                                           \
-       /var/log/*                                                     \
-       /tmp/*                                                         \
-       /var/tmp/*                                                     \
-       /usr/share/doc/*                                               \
-       /usr/share/man/*                                               \
-       /usr/share/local/* &&                                          \
-                                                                      \
+# Install Docker
+RUN apt-get update && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh \
     # Add user "admin" to the Docker group
-    usermod -a -G docker admin
+    && usermod -a -G docker admin
+ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker /etc/bash_completion.d/docker.sh
 
-# Sshd install
-RUN apt-get update && apt-get install --no-install-recommends -y      \
-            openssh-server &&                                         \
-    mkdir /home/admin/.ssh &&                                         \
-    chown admin:admin /home/admin/.ssh
+# Install Sshd
+RUN apt-get update && apt-get install --no-install-recommends -y openssh-server \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /home/admin/.ssh \
+    && chown admin:admin /home/admin/.ssh
 
 EXPOSE 22
 
 # Set systemd as entrypoint.
 ENTRYPOINT [ "/sbin/init", "--log-level=err" ]
-

--- a/ubuntu-focal-systemd/Dockerfile
+++ b/ubuntu-focal-systemd/Dockerfile
@@ -51,6 +51,14 @@ RUN apt-get update &&                            \
     # Create default 'admin/admin' user
     useradd --create-home --shell /bin/bash admin && echo "admin:admin" | chpasswd && adduser admin sudo
 
+# Disable systemd services/units that are unnecessary within a container.
+RUN systemctl mask systemd-udevd.service \
+                   systemd-udevd-kernel.socket \
+                   systemd-udevd-control.socket \
+                   systemd-modules-load.service \
+                   sys-kernel-debug.mount \
+                   sys-kernel-tracing.mount
+
 # Make use of stopsignal (instead of sigterm) to stop systemd containers.
 STOPSIGNAL SIGRTMIN+3
 

--- a/ubuntu-jammy-systemd-docker/Dockerfile
+++ b/ubuntu-jammy-systemd-docker/Dockerfile
@@ -13,52 +13,25 @@
 # where <host-port> is chosen by Docker and mapped into the system container's sshd port.
 #
 
-FROM nestybox/ubuntu-jammy-systemd:latest
+FROM ghcr.io/nestybox/ubuntu-jammy-systemd:latest
 
-# Docker install
-RUN apt-get update && apt-get install --no-install-recommends -y      \
-       apt-transport-https                                            \
-       ca-certificates                                                \
-       curl                                                           \
-       gnupg-agent                                                    \
-       software-properties-common &&                                  \
-                                                                      \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg           \
-         | apt-key add - &&                                           \
-	                                                              \
-    apt-key fingerprint 0EBFCD88 &&                                   \
-                                                                      \
-    add-apt-repository                                                \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu     \
-       $(lsb_release -cs)                                             \
-       stable" &&                                                     \
-                                                                      \
-    apt-get update && apt-get install --no-install-recommends -y      \
-       docker-ce docker-ce-cli containerd.io &&                       \
-                                                                      \
-    # Housekeeping
-    apt-get clean -y &&                                               \
-    rm -rf                                                            \
-       /var/cache/debconf/*                                           \
-       /var/lib/apt/lists/*                                           \
-       /var/log/*                                                     \
-       /tmp/*                                                         \
-       /var/tmp/*                                                     \
-       /usr/share/doc/*                                               \
-       /usr/share/man/*                                               \
-       /usr/share/local/* &&                                          \
-                                                                      \
+# Install Docker
+RUN apt-get update && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh \
     # Add user "admin" to the Docker group
-    usermod -a -G docker admin
+    && usermod -a -G docker admin
+ADD https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker /etc/bash_completion.d/docker.sh
 
-# Sshd install
-RUN apt-get update && apt-get install --no-install-recommends -y      \
-            openssh-server &&                                         \
-    mkdir /home/admin/.ssh &&                                         \
-    chown admin:admin /home/admin/.ssh
+# Install Sshd
+RUN apt-get update && apt-get install --no-install-recommends -y openssh-server \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /home/admin/.ssh \
+    && chown admin:admin /home/admin/.ssh
 
 EXPOSE 22
 
 # Set systemd as entrypoint.
 ENTRYPOINT [ "/sbin/init", "--log-level=err" ]
+
 

--- a/ubuntu-jammy-systemd/Dockerfile
+++ b/ubuntu-jammy-systemd/Dockerfile
@@ -51,6 +51,14 @@ RUN apt-get update &&                            \
     # Create default 'admin/admin' user
     useradd --create-home --shell /bin/bash admin && echo "admin:admin" | chpasswd && adduser admin sudo
 
+# Disable systemd services/units that are unnecessary within a container.
+RUN systemctl mask systemd-udevd.service \
+                   systemd-udevd-kernel.socket \
+                   systemd-udevd-control.socket \
+                   systemd-modules-load.service \
+                   sys-kernel-debug.mount \
+                   sys-kernel-tracing.mount
+
 # Make use of stopsignal (instead of sigterm) to stop systemd containers.
 STOPSIGNAL SIGRTMIN+3
 


### PR DESCRIPTION
The goal here is to prevent systemd from wasting cycles attempting to run services/units that are not applicable within a sys container. These changes are part of the effort initiated to reduce Sysbox's kernel-module dependencies (i.e., configfs, debugfs, tracefs).

As part of these changes we have also simplified the docker installation process in the Dockerfiles being modified.

Also, the images associated to every Dockerfile being touched, as well as those that depend on these ones, have been rebuilt and updated in ghcr.io.

Signed-off-by: Rodny Molina <rmolina@nestybox.com>