### PR TITLE
Disable e2scrub_reap.service in Ubuntu Noble systemd image.

### DIFF
--- a/ubuntu-noble-systemd/Dockerfile
+++ b/ubuntu-noble-systemd/Dockerfile
@@ -58,7 +58,8 @@ RUN systemctl mask systemd-udevd.service \
                    systemd-modules-load.service \
                    sys-kernel-debug.mount \
                    sys-kernel-tracing.mount \
-                   sys-kernel-config.mount
+                   sys-kernel-config.mount \
+                   e2scrub_reap.service
 
 # Make use of stopsignal (instead of sigterm) to stop systemd containers.
 STOPSIGNAL SIGRTMIN+3


### PR DESCRIPTION
The e2scrub_reap.service in systemd performs cleanup / scrubbing of file system for ext-based file systems (like ext4 or ext3).

This service, when running inside a Sysbox container, is causing high CPU utilization on the host, likely because it's walking the container filesystem and causing high CPU utilization once it hits the files under `/proc` and `/sys` emulated by Sysbox.

Since the service is not really needed inside a Sysbox container (it should ideally just run at host level), disable it in the `nestybox/ubuntu-noble-systemd` image.