### PR TITLE
Fix user config in jenkins-syscont.

### DIFF
--- a/jenkins-syscont/Dockerfile
+++ b/jenkins-syscont/Dockerfile
@@ -23,6 +23,7 @@ RUN add-apt-repository \
        stable"
 RUN apt-get update && apt-get install --no-install-recommends -y \
        docker-ce docker-ce-cli containerd.io
+RUN usermod -aG docker jenkins
 
 #
 # supervisord
@@ -38,4 +39,3 @@ COPY docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 RUN chmod +x /usr/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
-

--- a/jenkins-syscont/supervisord.conf
+++ b/jenkins-syscont/supervisord.conf
@@ -15,4 +15,4 @@ priority=2
 autostart=true
 autorestart=true
 startsecs=0
-username=jenkins
+user=jenkins


### PR DESCRIPTION
Use "user" instead of "username" (the latter belongs to configuration of [unix_http_server], which is not what we want).

Fixes Sysbox issue 786.